### PR TITLE
Deprecate `Thunk` on `f` currying function

### DIFF
--- a/src/Thunks.jl
+++ b/src/Thunks.jl
@@ -68,7 +68,6 @@ mutable struct Thunk <: Think
     end
 end
 Thunk(f, args...; kwargs...) = Thunk(f, args, kwargs)
-Thunk(f) = (args...; kwargs...) -> Thunk(f, args, kwargs)
 
 mutable struct TimeLimitedThunk <: Think
     time_limit::Period

--- a/test/run!.jl
+++ b/test/run!.jl
@@ -29,10 +29,10 @@ using EasyJobsBase.Thunks
         cos(x)
         return run(`pwd` & `ls`)
     end
-    i = Job(Thunk(f₁, ()); username="me", name="i")
+    i = Job(Thunk(f₁); username="me", name="i")
     j = Job(Thunk(f₂, 3); username="he", name="j")
     k = Job(Thunk(f₃, 6); name="k")
-    l = Job(Thunk(f₄, ()); name="l", username="me")
+    l = Job(Thunk(f₄); name="l", username="me")
     m = Job(Thunk(f₅, 3, 1); name="m")
     n = Job(Thunk(f₆, 1; x=3); username="she", name="n")
     for job in (i, j, k, l, m, n)

--- a/test/run!.jl
+++ b/test/run!.jl
@@ -37,6 +37,7 @@ using EasyJobsBase.Thunks
     n = Job(Thunk(f₆, 1; x=3); username="she", name="n")
     for job in (i, j, k, l, m, n)
         run!(job)
+        wait(job)
         @test issucceeded(job)
     end
 end


### PR DESCRIPTION
Before this PR, code

```julia
Thunk(f) = (args...; kwargs...) -> Thunk(f, args, kwargs)
```

will treat `Thunk(f, ())` as a funtion with an empty `Tuple` as its argument. It is wrong for functions without any argument.