### PR TITLE
Deprecate all functions in operations.jl except `chain!`

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -20,16 +20,16 @@ function chain!(x::AbstractJob, y::AbstractJob)
     return x
 end
 chain!(x::AbstractJob, y::AbstractJob, z::AbstractJob...) = foldr(chain!, (x, y, z...))
-function chain!(x::DependentJob, y::DependentJob)
-    chain!(x, y)
-    y.strict = true
-    return x
-end
-function chain!(x::ArgDependentJob, y::ArgDependentJob)
-    chain!(x, y)
-    push!(y.args_from, x)
-    return x
-end
+# function chain!(x::DependentJob, y::DependentJob)
+#     chain!(x, y)
+#     y.strict = true
+#     return x
+# end
+# function chain!(x::ArgDependentJob, y::ArgDependentJob)
+#     chain!(x, y)
+#     push!(y.args_from, x)
+#     return x
+# end
 """
     →(x, y)
 

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,4 +1,4 @@
-export chain!, follow!, pipe!, spindle!, →, ←, ↠, ↞, ⇒, ⇐
+export chain!, follow!, pipe!, →, ←, ↠, ↞, ⇒, ⇐
 
 """
     chain(x::Job, y::Job, z::Job...)
@@ -66,10 +66,3 @@ pipe!(x::AbstractJob, y::AbstractJob, z::AbstractJob...) = foldr(pipe!, (x, y, z
 "Pipe" two jobs reversely.
 """
 ⇐(y::AbstractJob, x::AbstractJob) = x ⇒ y
-
-"""
-    spindle(x::Job, ys::AbstractVector{Job}, z::Job)
-
-Start from a `Job` (`x`), followed by a series of `Job`s (`ys`), finished by a single `Job` (`z`).
-"""
-spindle!(x::AbstractJob, ys::AbstractVector, z::AbstractJob) = x ⇉ ys ⭃ z

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -44,7 +44,7 @@ follow!(x::AbstractJob, y::AbstractJob, z::AbstractJob...) = foldr(follow!, (x, 
 ↞(y::AbstractJob, x::AbstractJob) = x ↠ y
 
 """
-    pipe(x::Job, y::Job, z::Job...)
+    pipe!(x::Job, y::Job, z::Job...)
 
 Chain multiple jobs one after another, as well as
 directing the returned value of one job to the input of another.

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,7 +1,7 @@
 export chain!, →, ←
 
 """
-    chain(x::Job, y::Job, z::Job...)
+    chain!(x::Job, y::Job, z::Job...)
 
 Chain multiple `Job`s one after another.
 """

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,4 +1,4 @@
-export chain!, follow!, pipe!, converge!, spindle!, →, ←, ↠, ↞, ⇒, ⇐, ⭃
+export chain!, follow!, pipe!, spindle!, →, ←, ↠, ↞, ⇒, ⇐
 
 """
     chain(x::Job, y::Job, z::Job...)
@@ -66,20 +66,6 @@ pipe!(x::AbstractJob, y::AbstractJob, z::AbstractJob...) = foldr(pipe!, (x, y, z
 "Pipe" two jobs reversely.
 """
 ⇐(y::AbstractJob, x::AbstractJob) = x ⇒ y
-
-"""
-    converge(xs::AbstractVector{Job}, y::Job)
-    ⭃(xs, y)
-
-Finish a group a parallel `Job`s (`xs`) by a single `Job` (`y`).
-"""
-function converge!(xs::AbstractVector, y::AbstractJob)
-    for x in xs
-        chain!(x, y)
-    end
-    return xs
-end
-const ⭃ = converge!
 
 """
     spindle(x::Job, ys::AbstractVector{Job}, z::Job)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,4 +1,4 @@
-export chain!, pipe!, →, ←, ⇒, ⇐
+export chain!, →, ←
 
 """
     chain(x::Job, y::Job, z::Job...)
@@ -25,6 +25,11 @@ function chain!(x::DependentJob, y::DependentJob)
     y.strict = true
     return x
 end
+function chain!(x::ArgDependentJob, y::ArgDependentJob)
+    chain!(x, y)
+    push!(y.args_from, x)
+    return x
+end
 """
     →(x, y)
 
@@ -37,28 +42,3 @@ Chain two `Job`s.
 Chain two `Job`s reversely.
 """
 ←(y::AbstractJob, x::AbstractJob) = x → y
-
-"""
-    pipe!(x::Job, y::Job, z::Job...)
-
-Chain multiple jobs one after another, as well as
-directing the returned value of one job to the input of another.
-"""
-function pipe!(x::AbstractJob, y::AbstractJob)
-    chain!(x, y)
-    push!(y.args_from, x)
-    return x
-end
-pipe!(x::AbstractJob, y::AbstractJob, z::AbstractJob...) = foldr(pipe!, (x, y, z...))
-"""
-    ⇒(x, y)
-
-"Pipe" two jobs together.
-"""
-⇒(x::AbstractJob, y::AbstractJob) = pipe!(x, y)
-"""
-    ⇐(x, y)
-
-"Pipe" two jobs reversely.
-"""
-⇐(y::AbstractJob, x::AbstractJob) = x ⇒ y

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,4 +1,4 @@
-export chain!, follow!, pipe!, →, ←, ↠, ↞, ⇒, ⇐
+export chain!, pipe!, →, ←, ⇒, ⇐
 
 """
     chain(x::Job, y::Job, z::Job...)
@@ -20,6 +20,11 @@ function chain!(x::AbstractJob, y::AbstractJob)
     return x
 end
 chain!(x::AbstractJob, y::AbstractJob, z::AbstractJob...) = foldr(chain!, (x, y, z...))
+function chain!(x::DependentJob, y::DependentJob)
+    chain!(x, y)
+    y.strict = true
+    return x
+end
 """
     →(x, y)
 
@@ -32,15 +37,6 @@ Chain two `Job`s.
 Chain two `Job`s reversely.
 """
 ←(y::AbstractJob, x::AbstractJob) = x → y
-
-function follow!(x::AbstractJob, y::AbstractJob)
-    chain!(x, y)
-    y.strict = true
-    return x
-end
-follow!(x::AbstractJob, y::AbstractJob, z::AbstractJob...) = foldr(follow!, (x, y, z...))
-↠(x::AbstractJob, y::AbstractJob) = follow!(x, y)
-↞(y::AbstractJob, x::AbstractJob) = x ↠ y
 
 """
     pipe!(x::Job, y::Job, z::Job...)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,4 +1,4 @@
-export chain!, follow!, pipe!, fork!, converge!, spindle!, →, ←, ↠, ↞, ⇒, ⇐, ⇉, ⭃
+export chain!, follow!, pipe!, converge!, spindle!, →, ←, ↠, ↞, ⇒, ⇐, ⭃
 
 """
     chain(x::Job, y::Job, z::Job...)
@@ -66,20 +66,6 @@ pipe!(x::AbstractJob, y::AbstractJob, z::AbstractJob...) = foldr(pipe!, (x, y, z
 "Pipe" two jobs reversely.
 """
 ⇐(y::AbstractJob, x::AbstractJob) = x ⇒ y
-
-"""
-    fork(x::Job, ys::AbstractVector{Job})
-    ⇉(x, ys)
-
-Attach a group of parallel `Job`s (`ys`) to a single `Job` (`x`).
-"""
-function fork!(x::AbstractJob, ys::AbstractVector)
-    for y in ys
-        chain!(x, y)
-    end
-    return x
-end
-const ⇉ = fork!
 
 """
     converge(xs::AbstractVector{Job}, y::Job)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,5 +1,4 @@
-export chain!,
-    follow!, pipe!, thread!, fork!, converge!, spindle!, →, ←, ↠, ↞, ⇒, ⇐, ⇶, ⬱, ⇉, ⭃
+export chain!, follow!, pipe!, fork!, converge!, spindle!, →, ←, ↠, ↞, ⇒, ⇐, ⇉, ⭃
 
 """
     chain(x::Job, y::Job, z::Job...)
@@ -67,36 +66,6 @@ pipe!(x::AbstractJob, y::AbstractJob, z::AbstractJob...) = foldr(pipe!, (x, y, z
 "Pipe" two jobs reversely.
 """
 ⇐(y::AbstractJob, x::AbstractJob) = x ⇒ y
-
-"""
-    thread(xs::AbstractVector{Job}, ys::AbstractVector{Job}, zs::AbstractVector{Job}...)
-
-Chain multiple vectors of `Job`s, each `Job` in `xs` has a corresponding `Job` in `ys`.`
-"""
-function thread!(xs::AbstractVector, ys::AbstractVector)
-    if size(xs) != size(ys)
-        throw(DimensionMismatch("`xs` and `ys` must have the same size!"))
-    end
-    for (x, y) in zip(xs, ys)
-        chain!(x, y)
-    end
-    return xs
-end
-function thread!(xs::AbstractVector, ys::AbstractVector, zs::AbstractVector...)
-    return foldr(thread!, (xs, ys, zs...))
-end
-"""
-    ⇶(xs, ys)
-
-Chain two vectors of `Job`s.
-"""
-⇶(xs::AbstractVector, ys::AbstractVector) = thread!(xs, ys)
-"""
-    ⬱(ys, xs)
-
-Chain two vectors of `Job`s reversely.
-"""
-⬱(ys::AbstractVector, xs::AbstractVector) = xs ⇶ ys
 
 """
     fork(x::Job, ys::AbstractVector{Job})

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -9,11 +9,16 @@ Chain multiple `Job`s one after another.
 function chain!(x::AbstractJob, y::AbstractJob)
     if x == y
         throw(ArgumentError("a job cannot be followed by itself!"))
+    end
+    if y in x.children && x in y.parents
+        @info "You cannot chain the same jobs twice! No operations will be done!"
+    elseif y in x.children || x in y.parents  # This should never happen
+        error("Only one job is linked to the other, something is wrong!")
     else
         push!(x.children, y)
         push!(y.parents, x)
-        return x
     end
+    return x
 end
 chain!(x::AbstractJob, y::AbstractJob, z::AbstractJob...) = foldr(chain!, (x, y, z...))
 """


### PR DESCRIPTION
For other operations, just use broadcasting of `chain!`