### PR TITLE
Completely rewrite `AsyncExecutor`, `execute!` & `singlerun!`

### DIFF
--- a/src/run.jl
+++ b/src/run.jl
@@ -15,18 +15,17 @@ Handle the execution of jobs.
 - `interval::Real=1`: the time interval between each attempt to execute the job, in seconds.
 - `delay::Real=0`: the delay before the first attempt to execute the job, in seconds.
 """
-mutable struct Executor{T<:AbstractJob}
-    job::T
+mutable struct Executor
     wait::Bool
     maxattempts::UInt64
     interval::Real
     delay::Real
     task::Task
-    function Executor(job::T; wait=false, maxattempts=1, interval=1, delay=0) where {T}
+    function Executor(wait=false, maxattempts=1, interval=1, delay=0)
         @assert maxattempts >= 1
         @assert interval >= zero(interval)
         @assert delay >= zero(delay)
-        return new{T}(job, wait, maxattempts, interval, delay, @task _run!(job))
+        return new(wait, maxattempts, interval, delay)
     end
 end
 

--- a/src/run.jl
+++ b/src/run.jl
@@ -17,20 +17,18 @@ Handle the execution of jobs.
 - `delay::Real=0`: the delay before the first attempt to execute the job, in seconds.
 """
 mutable struct AsyncExecutor <: Executor
-    wait::Bool
     maxattempts::UInt64
     interval::Real
     delay::Real
-    task::Task
-    function AsyncExecutor(wait=false, maxattempts=1, interval=1, delay=0)
+    function AsyncExecutor(maxattempts=1, interval=1, delay=0)
         @assert maxattempts >= 1
         @assert interval >= zero(interval)
         @assert delay >= zero(delay)
-        return new(wait, maxattempts, interval, delay)
+        return new(maxattempts, interval, delay)
     end
 end
-AsyncExecutor(; wait=false, maxattempts=1, interval=1, delay=0) =
-    AsyncExecutor(wait, maxattempts, interval, delay)
+AsyncExecutor(; maxattempts=1, interval=1, delay=0) =
+    AsyncExecutor(maxattempts, interval, delay)
 
 function dispatch!(exec::AsyncExecutor, job::AbstractJob)
     exec.task = @task _run!(job)  # Start a new task. This is necessary for rerunning!

--- a/src/run.jl
+++ b/src/run.jl
@@ -163,21 +163,3 @@ function shouldrun(job::ArgDependentJob)
         end
     end
 end
-
-"""
-    kill!(exec::Executor)
-
-Manually kill a `Job`, works only if it is running.
-"""
-function Base.kill(exec::AsyncExecutor)
-    _kill(exec.task)
-    return nothing
-end
-
-"""
-    Base.wait(exec::Executor)
-
-Overloads the Base `wait` function to wait for the `Task` associated with an `Executor`
-object to complete.
-"""
-Base.wait(exec::AsyncExecutor) = wait(exec.task)

--- a/src/run.jl
+++ b/src/run.jl
@@ -59,7 +59,7 @@ function execute!(job::AbstractJob, exec::AsyncExecutor)
     if !issucceeded(job)
         sleep(exec.delay)
         task = @task for _ in Base.OneTo(exec.maxattempts)
-            subtask = singlerun!(exec, job)
+            subtask = singlerun!(job)
             wait(subtask)
             if issucceeded(job)
                 break  # Stop immediately if the job has succeeded
@@ -70,10 +70,10 @@ function execute!(job::AbstractJob, exec::AsyncExecutor)
     return task  # Stop immediately if the job has succeeded
 end
 
-function singlerun!(exec::AsyncExecutor, job::AbstractJob)
+function singlerun!(job::AbstractJob)
     if isfailed(job) || isinterrupted(job)
         job.status = PENDING
-        return singlerun!(exec, job)
+        return singlerun!(job)
     end
     if ispending(job)
         task = dispatch!(job)

--- a/src/run.jl
+++ b/src/run.jl
@@ -166,15 +166,9 @@ end
 
 Manually kill a `Job`, works only if it is running.
 """
-function Base.kill(exec::Executor, job::AbstractJob)
-    if isexited(job)
-        @info "the job $(job.id) has already exited!"
-    elseif ispending(job)
-        @info "the job $(job.id) has not started!"
-    else
-        _kill(exec.task)
-    end
-    return exec
+function Base.kill(exec::Executor)
+    _kill(exec.task)
+    return nothing
 end
 
 """

--- a/src/run.jl
+++ b/src/run.jl
@@ -1,6 +1,6 @@
 using Thinkers: TimeoutException, ErrorInfo, reify!, setargs!, haserred, _kill
 
-export shouldrun, run!, execute!, kill!
+export shouldrun, run!, execute!
 
 # See https://github.com/MineralsCloud/SimpleWorkflows.jl/issues/137
 """

--- a/src/run.jl
+++ b/src/run.jl
@@ -30,10 +30,7 @@ end
 AsyncExecutor(; maxattempts=1, interval=1, delay=0) =
     AsyncExecutor(maxattempts, interval, delay)
 
-function dispatch!(exec::AsyncExecutor, job::AbstractJob)
-    exec.task = @task _run!(job)  # Start a new task. This is necessary for rerunning!
-    return exec
-end
+dispatch!(job::AbstractJob) = @task _run!(job)
 
 """
     run!(job::Job; wait=false, maxattempts=1, interval=1, delay=0)

--- a/src/run.jl
+++ b/src/run.jl
@@ -70,16 +70,6 @@ function execute!(job::AbstractJob, exec::AsyncExecutor)
     return task  # Stop immediately if the job has succeeded
 end
 
-"""
-    singlerun!(exec::Executor)
-
-Executes a single run of the job associated with the `Executor` object.
-
-This function checks the job status. If the job is pending, it schedules the task and waits
-if `wait` is `true`. If the job has failed or been interrupted, it creates a new task,
-resets the job status to `PENDING`, and then calls `singlerun!` again. If the job is running
-or has succeeded, it does nothing and returns the `Executor` object.
-"""
 function singlerun!(exec::AsyncExecutor, job::AbstractJob)
     if isfailed(job) || isinterrupted(job)
         job.status = PENDING

--- a/src/run.jl
+++ b/src/run.jl
@@ -84,6 +84,7 @@ resets the job status to `PENDING`, and then calls `singlerun!` again. If the jo
 or has succeeded, it does nothing and returns the `Executor` object.
 """
 function singlerun!(exec::Executor, job::AbstractJob)
+    dispatch!(exec, job)  # In case `exec.task` is not initialized
     if ispending(job)
         schedule(exec.task)
         if exec.wait
@@ -91,7 +92,6 @@ function singlerun!(exec::Executor, job::AbstractJob)
         end
     end
     if isfailed(job) || isinterrupted(job)
-        dispatch!(exec, job)
         job.status = PENDING
         return singlerun!(exec, job)  # Wait or not depends on `exec.wait`
     end

--- a/src/run.jl
+++ b/src/run.jl
@@ -83,17 +83,17 @@ if `wait` is `true`. If the job has failed or been interrupted, it creates a new
 resets the job status to `PENDING`, and then calls `singlerun!` again. If the job is running
 or has succeeded, it does nothing and returns the `Executor` object.
 """
-function singlerun!(exec::Executor)
-    if ispending(exec.job)
+function singlerun!(exec::Executor, job::AbstractJob)
+    if ispending(job)
         schedule(exec.task)
         if exec.wait
             wait(exec)
         end
     end
-    if isfailed(exec.job) || isinterrupted(exec.job)
-        newtask!(exec)
-        exec.job.status = PENDING
-        return singlerun!(exec)  # Wait or not depends on `exec.wait`
+    if isfailed(job) || isinterrupted(job)
+        dispatch!(exec, job)
+        job.status = PENDING
+        return singlerun!(exec, job)  # Wait or not depends on `exec.wait`
     end
     return exec  # Do nothing for running and succeeded jobs
 end

--- a/src/run.jl
+++ b/src/run.jl
@@ -166,11 +166,11 @@ end
 
 Manually kill a `Job`, works only if it is running.
 """
-function kill!(exec::Executor)
-    if isexited(exec.job)
-        @info "the job $(exec.job.id) has already exited!"
-    elseif ispending(exec.job)
-        @info "the job $(exec.job.id) has not started!"
+function Base.kill(exec::Executor, job::AbstractJob)
+    if isexited(job)
+        @info "the job $(job.id) has already exited!"
+    elseif ispending(job)
+        @info "the job $(job.id) has not started!"
     else
         _kill(exec.task)
     end

--- a/src/run.jl
+++ b/src/run.jl
@@ -29,8 +29,8 @@ mutable struct Executor
     end
 end
 
-function newtask!(exec::Executor)
-    exec.task = @task _run!(exec.job)  # Start a new task. This is necessary for rerunning!
+function dispatch!(exec::Executor, job::AbstractJob)
+    exec.task = @task _run!(job)  # Start a new task. This is necessary for rerunning!
     return exec
 end
 

--- a/src/run.jl
+++ b/src/run.jl
@@ -29,6 +29,8 @@ mutable struct AsyncExecutor <: Executor
         return new(wait, maxattempts, interval, delay)
     end
 end
+AsyncExecutor(; wait=false, maxattempts=1, interval=1, delay=0) =
+    AsyncExecutor(wait, maxattempts, interval, delay)
 
 function dispatch!(exec::AsyncExecutor, job::AbstractJob)
     exec.task = @task _run!(job)  # Start a new task. This is necessary for rerunning!

--- a/src/run.jl
+++ b/src/run.jl
@@ -41,17 +41,14 @@ and an initial `delay` in seconds.
 run!(job::AbstractJob; kwargs...) = execute!(job, AsyncExecutor(; kwargs...))
 
 """
-    execute!(exec::Executor)
+    execute!(job::AbstractJob, exec::AsyncExecutor)
 
-Execute a given job associated with the `Executor` object.
+Execute a given `AbstractJob` associated with the `AsyncExecutor`.
 
-This function checks if the job has succeeded. If not, it sleeps for a delay,
-runs the job once using `singlerun!`. If `maxattempts` is more than ``1``, it loops over
-the remaining attempts, sleeping for an interval, running the job, and waiting in each loop.
-If the job has already succeeded, it stops immediately.
-
-# Arguments
-- `exec::Executor`: the `Executor` object containing the job to be executed.
+This function checks if the `job` has succeeded. If so, it stops immediately. If not, it
+sleeps for a `exec.delay`, then runs the `job`. If `exec.maxattempts` is more than ``1``, it
+loops over the remaining attempts, sleeping for an `exec.interval`, running the `job`, and
+waiting in each loop.
 """
 function execute!(job::AbstractJob, exec::AsyncExecutor)
     @assert shouldrun(job)

--- a/src/run.jl
+++ b/src/run.jl
@@ -81,18 +81,15 @@ resets the job status to `PENDING`, and then calls `singlerun!` again. If the jo
 or has succeeded, it does nothing and returns the `Executor` object.
 """
 function singlerun!(exec::AsyncExecutor, job::AbstractJob)
-    dispatch!(exec, job)  # In case `exec.task` is not initialized
-    if ispending(job)
-        schedule(exec.task)
-        if exec.wait
-            wait(exec)
-        end
-    end
     if isfailed(job) || isinterrupted(job)
         job.status = PENDING
-        return singlerun!(exec, job)  # Wait or not depends on `exec.wait`
+        return singlerun!(exec, job)
     end
-    return exec  # Do nothing for running and succeeded jobs
+    if ispending(job)
+        task = dispatch!(job)
+        schedule(task)
+    end
+    return task  # Do nothing for running and succeeded jobs
 end
 
 # Internal function to execute a specific `AbstractJob`.

--- a/src/run.jl
+++ b/src/run.jl
@@ -40,7 +40,7 @@ end
 Run a `Job` with a maximum number of attempts, with each attempt separated by `interval` seconds
 and an initial `delay` in seconds.
 """
-run!(job::AbstractJob; kwargs...) = execute!(Executor(job; kwargs...))
+run!(job::AbstractJob; kwargs...) = execute!(job, Executor(; kwargs...))
 
 """
     execute!(exec::Executor)
@@ -55,17 +55,17 @@ If the job has already succeeded, it stops immediately.
 # Arguments
 - `exec::Executor`: the `Executor` object containing the job to be executed.
 """
-function execute!(exec::Executor)
-    @assert shouldrun(exec.job)
-    prepare!(exec.job)
-    if !issucceeded(exec.job)
+function execute!(job::AbstractJob, exec::Executor)
+    @assert shouldrun(job)
+    prepare!(job)
+    if !issucceeded(job)
         sleep(exec.delay)
-        singlerun!(exec)  # Wait or not depends on `exec.wait`
+        singlerun!(exec, job)  # Wait or not depends on `exec.wait`
         if exec.maxattempts > 1
             wait(exec)
             for _ in Base.OneTo(exec.maxattempts - 1)
                 sleep(exec.interval)
-                singlerun!(exec)
+                singlerun!(exec, job)
                 wait(exec)  # Wait no matter whether `exec.wait` is `true` or `false`
             end
         end

--- a/test/run.jl
+++ b/test/run.jl
@@ -78,8 +78,8 @@ end
         @assert n.parents == Set([l, m])
         @assert isempty(n.children)
         for job in (i, j, k, l, m, n)
-            exec = run!(job)
-            wait(exec)
+            task = run!(job)
+            wait(task)
             @test issucceeded(job)
         end
     end
@@ -95,15 +95,15 @@ end
     @test !shouldrun(j)
     @test_throws AssertionError run!(j)
     @test getresult(j) === nothing
-    exec = run!(h)
-    wait(exec)
+    task = run!(h)
+    wait(task)
     @test !shouldrun(j)
     @test_throws AssertionError run!(j)
     @test getresult(j) === nothing
-    exec = run!(i)
-    wait(exec)
-    exec = run!(j)
-    wait(exec)
+    task = run!(i)
+    wait(task)
+    task = run!(j)
+    wait(task)
     @test getresult(j) == Some("1001")
 end
 
@@ -117,17 +117,17 @@ end
     i → j → k
     @test !shouldrun(j)
     @test !shouldrun(k)
-    exec = run!(i)
-    wait(exec)
+    task = run!(i)
+    wait(task)
     @test getresult(i) == Some(25)
     @test shouldrun(j)
     @test !shouldrun(k)
-    exec = run!(j)
-    wait(exec)
+    task = run!(j)
+    wait(task)
     @test getresult(j) == Some(26)
     @test shouldrun(k)
-    exec = run!(k)
-    wait(exec)
+    task = run!(k)
+    wait(task)
     @test getresult(k) == Some(13.0)
 end
 
@@ -142,15 +142,15 @@ end
     l = ArgDependentJob(Thunk(f₄, ()); username="she", name="me")
     (i, j, k) .→ l
     @test !shouldrun(l)
-    execs = map((i, j, k)) do job
+    tasks = map((i, j, k)) do job
         run!(job)
     end
-    for exec in execs
-        wait(exec)
+    for task in tasks
+        wait(task)
     end
     @test shouldrun(l)
-    exec = run!(l)
-    wait(exec)
+    task = run!(l)
+    wait(task)
     @test getresult(i) == Some(25)
     @test getresult(j) == Some(4)
     @test getresult(k) == Some(3.0)

--- a/test/run.jl
+++ b/test/run.jl
@@ -6,10 +6,12 @@ using Thinkers
         n < 5 ? error("not the number we want!") : return n
     end
     i = Job(Thunk(f); username="me", name="i")
-    run!(i; maxattempts=10, interval=3)
+    task = run!(i; maxattempts=10, interval=3)
+    wait(task)
     count = countexecution(i)
     @test 1 <= count <= 10
-    run!(i; maxattempts=10, interval=3)
+    task = run!(i; maxattempts=10, interval=3)
+    wait(task)
     @test 1 <= countexecution(i) <= 20
 end
 


### PR DESCRIPTION
The previous version of [`singlerun!`](https://github.com/MineralsCloud/EasyJobsBase.jl/blob/bced1db5c766a668fca9deb46c43b8ce0b014285/src/run.jl#L87-L100) is wrong, it may cause `singlerun!` to be run many times even though it is designed to be run only once. It could happen when `exec.wait` is `true` & the job fails or is interrupted during running.

Also, the logic in `execute!` is confusing: if `exec.maxattempts=1`, it will return a running `Executor`, but if it is larger than `1`, it will wait until success or `exec.maxattempts` is reached.

And `Executor` is actually an `AsyncExecutor`, and having `job` & `task` as its fields is awkward, and `kill!(exec::Executor)` or `Base.wait(exec::Executor)` is also weird since we want to `wait` for a `Job`. And this also makes the interface (API) has strange signatures.

So I have completely rewritten this part of the code to make it simpler and more correct.