### PR TITLE
Deprecate `INTERRUPTED` in Enum `JobStatus`

### DIFF
--- a/src/jobs.jl
+++ b/src/jobs.jl
@@ -10,7 +10,6 @@ export Job, IndependentJob, ConditionalJob, ArgDependentJob
     RUNNING
     SUCCEEDED
     FAILED
-    INTERRUPTED
 end
 
 abstract type AbstractJob end

--- a/src/run.jl
+++ b/src/run.jl
@@ -137,12 +137,7 @@ function _run!(job::AbstractJob)  # Do not export!
     job.start_time = now()
     reify!(job.core)
     job.end_time = now()
-    job.status = if haserred(job.core)
-        e = something(getresult(job.core)).thrown
-        e isa Union{InterruptException,TimeoutException} ? INTERRUPTED : FAILED
-    else
-        SUCCEEDED
-    end
+    job.status = haserred(job.core) ? FAILED : SUCCEEDED
     job.count += 1
     return job
 end

--- a/src/status.jl
+++ b/src/status.jl
@@ -39,7 +39,7 @@ isrunning(job::AbstractJob) = getstatus(job) === RUNNING
 
 Test if the `job` has exited.
 """
-isexited(job::AbstractJob) = getstatus(job) in (SUCCEEDED, FAILED, INTERRUPTED)
+isexited(job::AbstractJob) = getstatus(job) in (SUCCEEDED, FAILED)
 
 """
     issucceeded(job::AbstractJob)
@@ -53,7 +53,7 @@ issucceeded(job::AbstractJob) = getstatus(job) === SUCCEEDED
 
 Test if the `job` failed during running.
 """
-isfailed(job::AbstractJob) = getstatus(job) in (FAILED, INTERRUPTED)
+isfailed(job::AbstractJob) = getstatus(job) === FAILED
 
 """
     listpending(jobs)


### PR DESCRIPTION
It's more complicated to use in workflows' design.